### PR TITLE
version 1133, fixes #7, SERIALIZE-HIDDEN in dataset definition no longer triggers an exception

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,2 +1,2 @@
 #Mon Mar 07 23:00:00 PDT 2016
-build.number=1132
+build.number=1133

--- a/build/build.txt
+++ b/build/build.txt
@@ -10,6 +10,6 @@
 5. paste the file in the temporary directory
 
 6. open a command prompt on that directory
-7. use this command line "ikvmc.exe  -out:proparse.net.dll  -keyfile:proparse.snk  -version:4.0.1.1130  proparse-1.0.jar  .\lib\*"
+7. use this command line "ikvmc.exe  -out:proparse.net.dll  -keyfile:proparse.snk  -version:4.0.1.1133  proparse-1.0.jar  .\lib\*"
 
 8. enjoy!

--- a/src/main/antlr/JPTreeParser.g
+++ b/src/main/antlr/JPTreeParser.g
@@ -1406,6 +1406,7 @@ definedatasetstate
 	:	#(	DEFINE (def_shared)? def_modifiers DATASET ID
 			(namespace_uri)? (namespace_prefix)? (xml_node_name)?
 			( #(SERIALIZENAME QSTRING) )?
+			(SERIALIZEHIDDEN)?
 			(REFERENCEONLY)?
 			FOR RECORD_NAME (COMMA RECORD_NAME)*
 			( data_relation ( (COMMA)? data_relation)* )?

--- a/src/main/antlr/TreeParser01.g
+++ b/src/main/antlr/TreeParser01.g
@@ -674,6 +674,7 @@ definedatasetstate
 			id:ID { push(action.defineSymbol(DATASET, #def, #id)); }
 			(namespace_uri)? (namespace_prefix)? (xml_node_name)?
 			( #(SERIALIZENAME QSTRING) )?
+			(SERIALIZEHIDDEN)?
 			(REFERENCEONLY)?
 			FOR tb1:tbl[CQ.INIT] {action.datasetTable(#tb1);}
 			(COMMA tb2:tbl[CQ.INIT] {action.datasetTable(#tb2);} )*

--- a/src/main/antlr/proparse.g
+++ b/src/main/antlr/proparse.g
@@ -1996,6 +1996,7 @@ button_opt
 definedatasetstate
 	:	DATASET identifier
 		(namespace_uri)? (namespace_prefix)? (xml_node_name)? (serialize_name)?
+		(SERIALIZEHIDDEN)?
 		(REFERENCEONLY)?
 		FOR record (COMMA record)*
 		(data_relation ( (COMMA)? data_relation)* )?

--- a/src/main/java/org/prorefactor/core/TokenTypes.java
+++ b/src/main/java/org/prorefactor/core/TokenTypes.java
@@ -1192,7 +1192,8 @@ public class TokenTypes implements JPTreeParserTokenTypes, TokenTypesI {
 		allTokens[DYNAMICCAST].keywordText = "DYNAMIC-CAST";
 		allTokens[XMLNODENAME].keywordText = "XML-NODE-NAME";
 		allTokens[FOREIGNKEYHIDDEN].keywordText = "FOREIGN-KEY-HIDDEN";
-		
+		allTokens[SERIALIZEHIDDEN].keywordText = "SERIALIZE-HIDDEN";
+
 		// Mike Fechner / Consultingwerk Ltd. 
 		allTokens[BLOCKLEVEL].keywordText = "BLOCK-LEVEL";
 		allTokens[GETCLASS].keywordText = "GET-CLASS";


### PR DESCRIPTION
This fixes the issue with dataset definition, tested successfully with this code sample :

```
DEFINE TEMP-TABLE table1 NO-UNDO
    FIELD field1 AS CHARACTER
    INDEX idx field1
    .

DEFINE DATASET dataset1
    SERIALIZE-HIDDEN
    FOR table1.
```

PS: Looks like https://github.com/Riverside-Software/proparse has done a lot of work on the proparse, did you check it?
